### PR TITLE
Don't assume that setup.py is in the cwd

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,19 @@
+import os
+
 from setuptools import setup
 
 # Don't forget to update __version__ in the module itself.
 version = '1.0.0'
+
+with open(os.path.join(os.path.dirname(__file__), "README.md")) as readme:
+    long_description = readme.read()
 
 setup(
     name='yieldfrom',
     version=version,
     description="A backport of the `yield from` semantic from Python 3.x to "
                 "Python 2.7",
-    long_description=open('README.md').read(),
+    long_description=long_description,
     license='MIT',
     author='Amir Rachum',
     author_email='amir@rachum.com',


### PR DESCRIPTION
(That's only the case after pip install has cd'ed, but other tools do not necessarily do so, like even pip download.)