### PR TITLE
Wrapping a non-generator

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -161,3 +161,20 @@ def test_exception_flow():
         yield 3
 
     assert list(gen()) == [1, 2, 3]
+
+
+def test_non_generator_wrapping():
+    """Test wrapping a non-generator function with ``yieldfrom``."""
+
+    @yieldfrom
+    def non_gen():
+        return 42
+
+    @yieldfrom
+    def gen():
+        yield From(non_gen())
+
+    with pytest.raises(AttributeError) as excinfo:
+        list(gen())
+
+    assert 'next' in str(excinfo.value)

--- a/yieldfrom.py
+++ b/yieldfrom.py
@@ -211,7 +211,7 @@ def get_stop_iteration_value(e_stop):
     return e_stop.args[0] if e_stop.args else None
 
 
-def gen_nice_close(gen):
+def close_safely(gen):
     """Close generator, ignore if has no ``close`` attribute."""
     try:
         _close = gen.close
@@ -277,7 +277,7 @@ def yieldfrom(generator_func):
                             except GeneratorExit:
                                 # Higher level caller called `close()`.
                                 # Close the subgenerator if possible.
-                                gen_nice_close(subgen)
+                                close_safely(subgen)
                                 raise
                             except BaseException:
                                 # Higher level caller called `throw()`.
@@ -348,6 +348,6 @@ def yieldfrom(generator_func):
             # `gen` raised an exception or caller called `close()` or generator
             # was garbage collected.
             # Close the generator if possible.
-            gen_nice_close(gen)
+            close_safely(gen)
 
     return wrapper

--- a/yieldfrom.py
+++ b/yieldfrom.py
@@ -211,6 +211,15 @@ def get_stop_iteration_value(e_stop):
     return e_stop.args[0] if e_stop.args else None
 
 
+def gen_nice_close(gen):
+    """Close generator, ignore if has no ``close`` attribute."""
+    try:
+        _close = gen.close
+    except AttributeError:
+        pass
+    else:
+        _close()
+
 
 def yieldfrom(generator_func):
     """Decorate a function to enable ``yield From(generator)``.
@@ -268,12 +277,7 @@ def yieldfrom(generator_func):
                             except GeneratorExit:
                                 # Higher level caller called `close()`.
                                 # Close the subgenerator if possible.
-                                try:
-                                    _close = subgen.close
-                                except AttributeError:
-                                    pass
-                                else:
-                                    _close()
+                                gen_nice_close(subgen)
                                 raise
                             except BaseException:
                                 # Higher level caller called `throw()`.
@@ -343,6 +347,7 @@ def yieldfrom(generator_func):
         finally:
             # `gen` raised an exception or caller called `close()` or generator
             # was garbage collected.
-            gen.close()
+            # Close the generator if possible.
+            gen_nice_close(gen)
 
     return wrapper


### PR DESCRIPTION
Raise correct error when wrapping a non-generator with `yieldfrom`.