### PR TITLE
Fix exception handling on sub-generator's first yield

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -169,7 +169,6 @@ def test_exception_before_first_yield():
     def raise_value_error():
         raise ValueError()
 
-    @yieldfrom
     def subgen():
         yield raise_value_error()
 

--- a/tests.py
+++ b/tests.py
@@ -163,6 +163,26 @@ def test_exception_flow():
     assert list(gen()) == [1, 2, 3]
 
 
+def test_exception_before_first_yield():
+    """Test an exception raised before the first `yield`."""
+
+    def raise_value_error():
+        raise ValueError()
+
+    @yieldfrom
+    def subgen():
+        yield raise_value_error()
+
+    @yieldfrom
+    def gen():
+        try:
+            yield From(subgen())
+        except ValueError:
+            yield 1
+
+    assert list(gen()) == [1]
+
+
 def test_non_generator_wrapping():
     """Test wrapping a non-generator function with ``yieldfrom``."""
 

--- a/yieldfrom.py
+++ b/yieldfrom.py
@@ -267,6 +267,8 @@ def yieldfrom(generator_func):
                         # value passed by `StopIteration`, push it into `gen`
                         # and get the next item.
                         item = gen.send(get_stop_iteration_value(e_stop))
+                    except BaseException:
+                        item = gen.throw(*sys.exc_info())
                     else:
                         # INNER loop: iterate on values yielded by
                         # subgenerator.

--- a/yieldfrom.py
+++ b/yieldfrom.py
@@ -268,7 +268,12 @@ def yieldfrom(generator_func):
                         # and get the next item.
                         item = gen.send(get_stop_iteration_value(e_stop))
                     except BaseException:
+                        # `subgen` raised an exception before its first
+                        # `yield`. We give `gen` a chance to handle the raised
+                        # exception.
                         item = gen.throw(*sys.exc_info())
+                        # `subgen` raised an exception and `gen` caught it.
+                        # Execution will continue on the OUTER loop.
                     else:
                         # INNER loop: iterate on values yielded by
                         # subgenerator.


### PR DESCRIPTION
We're treating the first value of a sub-generator differently, this PR makes sure exceptions from that first yield are propagated properly to the parent generator.