### PR TITLE
Switch from next gen method to built in function

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -193,7 +193,7 @@ def test_non_generator_wrapping():
     def gen():
         yield From(non_gen())
 
-    with pytest.raises(AttributeError) as excinfo:
+    with pytest.raises(TypeError) as excinfo:
         list(gen())
 
-    assert 'next' in str(excinfo.value)
+    assert 'int' in str(excinfo.value)

--- a/yieldfrom.py
+++ b/yieldfrom.py
@@ -125,7 +125,7 @@ subgenerators:
         try:
             g = gen()
             while True:
-                i = g.next()
+                i = next(g)
                 if i == 2:
                     i = g.throw(ValueError())
             print i,
@@ -235,7 +235,7 @@ def yieldfrom(generator_func):
 
         try:
             # First poll of `gen`.
-            item = gen.next()
+            item = next(gen)
 
             # OUTER loop: iterate over all the values yielded by `gen`.
             while True:
@@ -261,7 +261,7 @@ def yieldfrom(generator_func):
                     subgen = item.iterator
                     try:
                         # First poll of `subgen`.
-                        subitem = subgen.next()
+                        subitem = next(subgen)
                     except StopIteration as e_stop:
                         # `subgen` exhausted on first poll. Extract return
                         # value passed by `StopIteration`, push it into `gen`
@@ -331,7 +331,7 @@ def yieldfrom(generator_func):
                                     if sent:
                                         subitem = subgen.send(sent)
                                     else:
-                                        subitem = subgen.next()
+                                        subitem = next(subgen)
                                 except StopIteration as e_stop:
                                     # `subgen` is exhausted. Retrieve its
                                     # return value, push it into `gen` and


### PR DESCRIPTION
.next() was deprecated in Python 3, so code that uses the `yieldfrom` package is not forward compatible
The next built-in introduced in Python 2.6 was the replacement, so swapping it in lets code be 2.6+ compatible